### PR TITLE
Set vbox memory size

### DIFF
--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -119,6 +119,10 @@ func vmCreate(c *VMConfig) error {
 	if err != nil {
 		return err
 	}
+	err = VBoxManage("modifyvm", c.Name, "--memory",  "1024")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
Default memeory size is 64MB. It is too small to start a OSv image=default
image.

Signed-off-by: Asias He asias@cloudius-systems.com
