### PR TITLE
vbox: Remove --hostonlyadapter1 option

### DIFF
--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -111,7 +111,7 @@ func vmCreate(c *VMConfig) error {
 	if err != nil {
 		return err
 	}
-	err = VBoxManage("modifyvm", c.Name, "--nic1", "nat", "--nictype1", "virtio", "--hostonlyadapter1", "vboxnet0")
+	err = VBoxManage("modifyvm", c.Name, "--nic1", "nat", "--nictype1", "virtio")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This option is needed only in --hostonly mode not in --nat mode.

Signed-off-by: Asias He asias@cloudius-systems.com
