### PR TITLE
Fix terminal handling on Windows

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cloudius-systems/capstan/hypervisor/vbox"
 	"github.com/cloudius-systems/capstan/image"
 	"github.com/cloudius-systems/capstan/nat"
-	"github.com/kylelemons/goat/termios"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,15 +73,8 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 	if err != nil {
 		return err
 	}
-	tio, err := termios.NewTermSettings(0)
-	if err != nil {
-		return err
-	}
-	err = tio.Raw()
-	if err != nil {
-		return err
-	}
-	defer tio.Reset()
+	tio, err := capstan.RawTerm()
+	defer capstan.ResetTerm(tio)
 	var cmd *exec.Cmd
 	switch config.Hypervisor {
 	case "qemu":

--- a/termios.go
+++ b/termios.go
@@ -1,0 +1,30 @@
+// +build linux darwin
+
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package capstan
+
+import (
+	"github.com/kylelemons/goat/termios"
+)
+
+func RawTerm() (*termios.TermSettings, error) {
+	tio, err := termios.NewTermSettings(0)
+	if err != nil {
+		return nil, err
+	}
+	err = tio.Raw()
+	if err != nil {
+		return nil, err
+	}
+	return tio, err
+}
+
+func ResetTerm(tio *termios.TermSettings) {
+	tio.Reset()
+}

--- a/termios_windows.go
+++ b/termios_windows.go
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package capstan
+
+func RawTerm() (int, error) {
+	return 0, nil
+}
+
+func ResetTerm(tio int) {
+}


### PR DESCRIPTION
The termios library does not work on Windows. Add a wrapper API to fix
compilation.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
