### PR TITLE
cmd/run: Fix cmd wait

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -129,7 +129,7 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 	if err != nil {
 		return err
 	}
-	if err != nil {
+	if cmd != nil {
 		return cmd.Wait()
 	} else {
 		return nil


### PR DESCRIPTION
It was supposed to check cmd insetad of err to decide to wait for the
cmd or not.

Signed-off-by: Asias He asias@cloudius-systems.com
