### PR TITLE
qemu: Fix capstan run with relative image path

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+	"path/filepath"
 )
 
 type VMConfig struct {
@@ -182,7 +183,12 @@ func LaunchVM(c *VMConfig, extra ...string) (*exec.Cmd, error) {
 			return nil, err
 		}
 
-		backingFile := "backing_file=" + c.Image
+		image, err := filepath.Abs(c.Image)
+		if err != nil {
+			fmt.Printf("Failed to open image %s\n", c.Image)
+			return nil, err
+		}
+		backingFile := "backing_file=" + image
 		newDisk := dir + "/disk.qcow2"
 		cmd = exec.Command("qemu-img", "create", "-f", "qcow2", "-o", backingFile, newDisk)
 		_, err = cmd.Output()


### PR DESCRIPTION
Pekka found this:

[penberg@localhost osv]$ capstan run build/release/usr.img
Created instance: i1396455503
qemu-system-x86_64: -drive
file=/home/penberg/.capstan/instances/qemu/i1396455503/disk.qcow2,if=none,id=hd0,aio=native,cache=none:
could not open disk image
/home/penberg/.capstan/instances/qemu/i1396455503/disk.qcow2: No such file or directory
exit status 1

The issue is that the image is a relative path so would be the
backing_file.

Fix it by making the backing_file a absolute path.

Signed-off-by: Asias He asias@cloudius-systems.com
