### PR TITLE
Fix grammar mistakes

### DIFF
--- a/capstan/capstan.go
+++ b/capstan/capstan.go
@@ -56,7 +56,7 @@ func main() {
 		},
 		{
 			Name:  "pull",
-			Usage: "pull an image to the repository",
+			Usage: "pull an image from a repository",
 			Flags: []cli.Flag{
 				cli.StringFlag{"p", hypervisor.Default(), "hypervisor"},
 			},
@@ -73,7 +73,7 @@ func main() {
 		},
 		{
 			Name:  "rmi",
-			Usage: "delete an image from an repository",
+			Usage: "delete an image from a repository",
 			Action: func(c *cli.Context) {
 				if len(c.Args()) != 1 {
 					fmt.Println("usage: capstan rmi [image-name]")


### PR DESCRIPTION
We were using every article possible with word "repository" in the
output of capstan -h:

   push     push an image to a repository
   pull     pull an image to the repository
   rmi      delete an image from an repository

Also, it should be "pull ... from". I consulted this with Don.
