### PR TITLE
vmw: Support VMware Worksation on Windows

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -138,7 +138,13 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 		if format != image.VMDK {
 			return fmt.Errorf("%s: image format of %s is not supported, unable to run it.", config.Hypervisor, path)
 		}
-		dir := filepath.Join(os.Getenv("HOME"), ".capstan/instances/vmw", id)
+		var homepath string
+		if runtime.GOOS == "windows" {
+			homepath = filepath.Join(os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"))
+		} else {
+			homepath = os.Getenv("HOME")
+		}
+		dir := filepath.Join(homepath, ".capstan/instances/vmw", id)
 		config := &vmw.VMConfig{
 			Name:     id,
 			Dir:      dir,

--- a/hypervisor/vmw/vmw_posix.go
+++ b/hypervisor/vmw/vmw_posix.go
@@ -1,0 +1,18 @@
+// +build linux darwin
+
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package vmw
+
+import (
+	"net"
+)
+
+func Connect(path string) (net.Conn, error) {
+	return net.Dial("unix", path)
+}

--- a/hypervisor/vmw/vmw_win.go
+++ b/hypervisor/vmw/vmw_win.go
@@ -1,0 +1,19 @@
+// +build windows
+
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package vmw
+
+import (
+	"net"
+	"github.com/natefinch/npipe"
+)
+
+func Connect(path string) (net.Conn, error) {
+	return npipe.Dial(path)
+}


### PR DESCRIPTION
Tested on VMWare Worksation on Windows/Linux and VMware Fusion on Mac

Note: VMware Player does not contain vmrun which required by capstan, so
we do not support VMware Player.

Fixes #53.

Signed-off-by: Asias He asias@cloudius-systems.com
