### PR TITLE
Move main package to top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ brew install qemu
 To install Capstan, type:
 
 ```
-$ go get github.com/cloudius-systems/capstan/capstan
+$ go get github.com/cloudius-systems/capstan
 ```
 
 This installs a ``capstan`` executable to your Go workspace so make sure your

--- a/capstan.go
+++ b/capstan.go
@@ -9,10 +9,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan"
 	"github.com/cloudius-systems/capstan/cmd"
 	"github.com/cloudius-systems/capstan/nat"
 	"github.com/cloudius-systems/capstan/hypervisor"
+	"github.com/cloudius-systems/capstan/util"
 	"github.com/codegangsta/cli"
 	"os"
 )
@@ -22,7 +22,7 @@ var (
 )
 
 func main() {
-	repo := capstan.NewRepo()
+	repo := util.NewRepo()
 	app := cli.NewApp()
 	app.Name = "capstan"
 	app.Version = VERSION
@@ -148,7 +148,7 @@ func main() {
 				if len(c.Args()) > 0 {
 					image = c.Args()[0]
 				}
-				capstan.ListImagesRemote(image)
+				util.ListImagesRemote(image)
 			},
 		},
 		{

--- a/capstan_test.go
+++ b/capstan_test.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package main
 
 import (
 	"fmt"

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,7 +9,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan"
+	"github.com/cloudius-systems/capstan/util"
 	"github.com/cloudius-systems/capstan/hypervisor/qemu"
 	"os"
 	"os/exec"
@@ -18,8 +18,8 @@ import (
 	"errors"
 )
 
-func Build(r *capstan.Repo, hypervisor string, image string, verbose bool) error {
-	config, err := capstan.ReadConfig("Capstanfile")
+func Build(r *util.Repo, hypervisor string, image string, verbose bool) error {
+	config, err := util.ReadConfig("Capstanfile")
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func Build(r *capstan.Repo, hypervisor string, image string, verbose bool) error
 	return nil
 }
 
-func checkConfig(config *capstan.Config, r *capstan.Repo, hypervisor string) error {
+func checkConfig(config *util.Config, r *util.Repo, hypervisor string) error {
 	if _, err := os.Stat(r.ImagePath(hypervisor, config.Base)); os.IsNotExist(err) {
 		err := Pull(r, hypervisor, config.Base)
 		if err != nil {

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -8,11 +8,11 @@
 package cmd
 
 import (
-	"github.com/cloudius-systems/capstan"
+	"github.com/cloudius-systems/capstan/util"
 )
 
-func Pull(r *capstan.Repo, hypervisor string, image string) error {
-	if capstan.IsRemoteImage(image) {
+func Pull(r *util.Repo, hypervisor string, image string) error {
+	if util.IsRemoteImage(image) {
 		return r.DownloadImage(hypervisor, image)
 	}
 	return r.PullImage(image)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,7 +9,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan"
 	"github.com/cloudius-systems/capstan/hypervisor/qemu"
 	"github.com/cloudius-systems/capstan/hypervisor/vbox"
 	"github.com/cloudius-systems/capstan/hypervisor/gce"
@@ -31,13 +30,13 @@ type RunConfig struct {
 	NatRules   []nat.Rule
 }
 
-func Run(repo *capstan.Repo, config *RunConfig) error {
+func Run(repo *util.Repo, config *RunConfig) error {
 	var path string
 	if config.ImageName != "" {
 		if _, err := os.Stat(config.ImageName); os.IsNotExist(err) {
 			if repo.ImageExists(config.Hypervisor, config.ImageName) {
 				path = repo.ImagePath(config.Hypervisor, config.ImageName)
-			} else if capstan.IsRemoteImage(config.ImageName) {
+			} else if util.IsRemoteImage(config.ImageName) {
 				err := Pull(repo, config.Hypervisor, config.ImageName)
 				if err != nil {
 					return err
@@ -55,7 +54,7 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 			return fmt.Errorf("No Capstanfile found, unable to run.")
 		}
 		if !repo.ImageExists(config.Hypervisor, config.ImageName) {
-			if !capstan.ConfigExists("Capstanfile") {
+			if !util.ConfigExists("Capstanfile") {
 				return fmt.Errorf("%s: no such image", config.ImageName)
 			}
 			err := Build(repo, config.Hypervisor, config.ImageName, config.Verbose)
@@ -72,7 +71,7 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 	if format == image.Unknown {
 		return fmt.Errorf("%s: image format not recognized, unable to run it.", path)
 	}
-	size, err := capstan.ParseMemSize(config.Memory)
+	size, err := util.ParseMemSize(config.Memory)
 	if err != nil {
 		return err
 	}
@@ -93,8 +92,8 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 			Monitor: filepath.Join(dir, "osv.monitor"),
 		}
 		fmt.Printf("Created instance: %s\n", id);
-		tio, _ := capstan.RawTerm()
-		defer capstan.ResetTerm(tio)
+		tio, _ := util.RawTerm()
+		defer util.ResetTerm(tio)
 		cmd, err = qemu.LaunchVM(config)
 		defer qemu.DeleteVM(config)
 	case "vbox":
@@ -111,8 +110,8 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 			NatRules: config.NatRules,
 		}
 		fmt.Printf("Created instance: %s\n", id);
-		tio, _ := capstan.RawTerm()
-		defer capstan.ResetTerm(tio)
+		tio, _ := util.RawTerm()
+		defer util.ResetTerm(tio)
 		cmd, err = vbox.LaunchVM(config)
 		defer vbox.DeleteVM(config)
 	case "gce":
@@ -146,8 +145,8 @@ func Run(repo *capstan.Repo, config *RunConfig) error {
 			OriginalVMDK: path,
 		}
 		fmt.Printf("Created instance: %s\n", id);
-		tio, _ := capstan.RawTerm()
-		defer capstan.ResetTerm(tio)
+		tio, _ := util.RawTerm()
+		defer util.ResetTerm(tio)
 		cmd, err = vmw.LaunchVM(config)
 		defer vmw.DeleteVM(config)
 	default:

--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -9,7 +9,6 @@ package qemu
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan"
 	"github.com/cloudius-systems/capstan/cpio"
 	"github.com/cloudius-systems/capstan/nat"
 	"github.com/cloudius-systems/capstan/nbd"
@@ -38,7 +37,7 @@ type VMConfig struct {
 	Monitor	string
 }
 
-func UploadRPM(r *capstan.Repo, hypervisor string, image string, config *capstan.Config, verbose bool) error {
+func UploadRPM(r *util.Repo, hypervisor string, image string, config *util.Config, verbose bool) error {
 	file := r.ImagePath(hypervisor, image)
 	vmconfig := &VMConfig{
 		Image:    file,
@@ -75,7 +74,7 @@ func UploadRPM(r *capstan.Repo, hypervisor string, image string, config *capstan
 	return err
 }
 
-func UploadFiles(r *capstan.Repo, hypervisor string, image string, config *capstan.Config, verbose bool) error {
+func UploadFiles(r *util.Repo, hypervisor string, image string, config *util.Config, verbose bool) error {
 	file := r.ImagePath(hypervisor, image)
 	vmconfig := &VMConfig{
 		Image:    file,
@@ -113,7 +112,7 @@ func UploadFiles(r *capstan.Repo, hypervisor string, image string, config *capst
 	return cmd.Wait()
 }
 
-func SetArgs(r *capstan.Repo, hypervisor, image string, args string) error {
+func SetArgs(r *util.Repo, hypervisor, image string, args string) error {
 	file := r.ImagePath(hypervisor, image)
 	cmd := exec.Command("qemu-nbd", file)
 	stdout, err := cmd.StdoutPipe()

--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-package=github.com/cloudius-systems/capstan/capstan
+package=github.com/cloudius-systems/capstan
 version=$(scripts/version)
 
 go get $package

--- a/install.bat
+++ b/install.bat
@@ -1,4 +1,4 @@
-set package=github.com/cloudius-systems/capstan/capstan
+set package=github.com/cloudius-systems/capstan
 for /f %%i in ('git describe --tags ') do set version=%%i
 go get %package%
 go install -ldflags "-X main.VERSION %version% " %package%

--- a/util/config.go
+++ b/util/config.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"github.com/kylelemons/go-gypsy/yaml"

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"github.com/kylelemons/go-gypsy/yaml"

--- a/util/github_repository.go
+++ b/util/github_repository.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"errors"

--- a/util/parser.go
+++ b/util/parser.go
@@ -1,4 +1,4 @@
-package capstan
+package util
 
 import (
 	"fmt"

--- a/util/parser_test.go
+++ b/util/parser_test.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"testing"

--- a/util/repository.go
+++ b/util/repository.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"errors"

--- a/util/rpm.go
+++ b/util/rpm.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"fmt"

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"encoding/xml"

--- a/util/termios.go
+++ b/util/termios.go
@@ -7,7 +7,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package util
 
 import (
 	"github.com/kylelemons/goat/termios"


### PR DESCRIPTION
Jussi Virtanen pointed out that the installation one-liner looks like a
typo because of the "capstan/capstan" postfix:

  go get github.com/cloudius-systems/capstan/capstan

Fix that by moving main package to top level.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
