### PR TITLE
Switch to new YAML library

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -8,81 +8,40 @@
 package util
 
 import (
-	"github.com/kylelemons/go-gypsy/yaml"
-	"strings"
+	"fmt"
+	"gopkg.in/yaml.v1"
+	"io/ioutil"
 )
 
 type Config struct {
 	Base    string
-	RpmBase *RpmPackage
+	RpmBase *RpmPackage "rpm-base"
 	Cmdline string
 	Build   string
 	Files   map[string]string
 }
 
 func ConfigExists(filename string) bool {
-	_, err := yaml.ReadFile(filename)
+	_, err := ReadConfig(filename)
 	return err == nil
 }
 
 func ReadConfig(filename string) (*Config, error) {
-	config, err := yaml.ReadFile(filename)
+	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return ParseConfig(config)
+	return ParseConfig(data)
 }
 
-func ParseConfig(config *yaml.File) (*Config, error) {
-	base, err := config.Get("base")
+func ParseConfig(data []byte) (*Config, error) {
+	c := Config{}
+	err := yaml.Unmarshal(data, &c)
 	if err != nil {
 		return nil, err
 	}
-	var rpm *RpmPackage = nil
-	rpmBaseNode, err := yaml.Child(config.Root, "rpm-base")
-	if err != nil {
-		return nil, err
+	if c.Cmdline == "" {
+		return nil, fmt.Errorf("\"cmdline\" not found")
 	}
-	if rpmBaseNode != nil {
-		rpmBaseMap := rpmBaseNode.(yaml.Map)
-		scalar := rpmBaseMap["name"].(yaml.Scalar)
-		name := strings.TrimSpace(scalar.String())
-		scalar = rpmBaseMap["version"].(yaml.Scalar)
-		version := strings.TrimSpace(scalar.String())
-		scalar = rpmBaseMap["release"].(yaml.Scalar)
-		release := strings.TrimSpace(scalar.String())
-		scalar = rpmBaseMap["arch"].(yaml.Scalar)
-		arch := strings.TrimSpace(scalar.String())
-		rpm = &RpmPackage{
-			Name:    name,
-			Version: version,
-			Release: release,
-			Arch:    arch,
-		}
-	}
-	cmdline, err := config.Get("cmdline")
-	if err != nil {
-		return nil, err
-	}
-	build, _ := config.Get("build")
-	filesNode, err := yaml.Child(config.Root, "files")
-	if err != nil {
-		return nil, err
-	}
-	files := make(map[string]string)
-	if filesNode != nil {
-		filesMap := filesNode.(yaml.Map)
-		for key, value := range filesMap {
-			scalar := value.(yaml.Scalar)
-			files[key] = strings.TrimSpace(scalar.String())
-		}
-	}
-	result := &Config{
-		Base:    base,
-		RpmBase: rpm,
-		Cmdline: cmdline,
-		Build:   build,
-		Files:   files,
-	}
-	return result, nil
+	return &c, nil
 }

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -8,7 +8,6 @@
 package util
 
 import (
-	"github.com/kylelemons/go-gypsy/yaml"
 	"testing"
 )
 
@@ -16,7 +15,7 @@ var configTests = []struct {
 	Spec string
 	Err  string
 }{
-	{"base: osv-base\n", "yaml: cmdline: \"cmdline\" not found"},
+	{"base: osv-base\n", "\"cmdline\" not found"},
 	{"base: osv-base\ncmdline: foo.so\n", ""},
 	{"base: osv-base\ncmdline: foo.so\nfiles:\n", ""},
 	{"base: osv-base\ncmdline: foo.so\nbuild: make\n", ""},
@@ -24,7 +23,7 @@ var configTests = []struct {
 
 func TestConfig(t *testing.T) {
 	for _, test := range configTests {
-		_, err := ParseConfig(yaml.Config(test.Spec))
+		_, err := ParseConfig([]byte(test.Spec))
 		var got string
 		switch err {
 		case nil:


### PR DESCRIPTION
The YAML parsing code is very verbose because of Gypsy. Switch to a new
YAML library suggested by Samuli Heljo that simplifies Capstan code a
lot.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
