### PR TITLE
qemu: Fix command lines that are longer than 512 bytes

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -144,7 +144,9 @@ func SetArgs(r *util.Repo, hypervisor, image string, args string) error {
 		return err
 	}
 
-	data := append([]byte(args), make([]byte, 512-len(args))...)
+	padding := 512 - (len(args) % 512)
+
+	data := append([]byte(args), make([]byte, padding)...)
 
 	if err := session.Write(512, data); err != nil {
 		return err


### PR DESCRIPTION
OSv image has 31.5 KB of space for command lines. Fix zero-padding for
command lines that are longer than 512 bytes.

Fixes #64.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
