### PR TITLE
vbox: Enable SSE 4.1 support

### DIFF
--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -144,6 +144,10 @@ func vmCreate(c *VMConfig) error {
 	if err != nil {
 		return err
 	}
+	err = VBoxManage("setextradata", c.Name, "VBoxInternal/CPUM/SSE4.1", "1")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
OSv is built with "-msse4.1" so enable SSE 4.1 support in VirtualBox.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
