### PR TITLE
Add GOPATH variable doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ On OS X:
 $ brew install qemu
 ```
 
+Make sure you have GOPATH variable set to point the 'bin' location of go installation:
+
+```
+$go env GOPATH
+```
+
+If not set:
+
+```
+export GOPATH=</usr/local/go/bin>
+```
+
 To install Capstan, type:
 
 ```


### PR DESCRIPTION
'go get'  will fail if GOPATH is not configured. Go install instructions url does not  mention this.
