### PR TITLE
qemu: Bridged networking support

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -92,7 +92,9 @@ func main() {
 				cli.StringFlag{"p", hypervisor.Default(), "hypervisor"},
 				cli.StringFlag{"m", "1G", "memory size"},
 				cli.IntFlag{"c", 2, "number of CPUs"},
+				cli.StringFlag{"n", "nat", "networking"},
 				cli.BoolFlag{"v", "verbose mode"},
+				cli.StringFlag{"b", "virbr0", "networking bridge"},
 				cli.StringSliceFlag{"f", new(cli.StringSlice), "port forwarding rules"},
 			},
 			Action: func(c *cli.Context) {
@@ -102,6 +104,8 @@ func main() {
 					Verbose:    c.Bool("v"),
 					Memory:     c.String("m"),
 					Cpus:       c.Int("c"),
+					Networking: c.String("n"),
+					Bridge:     c.String("b"),
 					NatRules:   nat.Parse(c.StringSlice("f")),
 				}
 				err := cmd.Run(repo, config)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,6 +27,8 @@ type RunConfig struct {
 	Verbose    bool
 	Memory     string
 	Cpus       int
+	Networking string
+	Bridge     string
 	NatRules   []nat.Rule
 }
 
@@ -112,16 +114,18 @@ func Run(repo *util.Repo, config *RunConfig) error {
 		id := util.ID()
 		dir := filepath.Join(os.Getenv("HOME"), ".capstan/instances/qemu", id)
 		config := &qemu.VMConfig{
-			Name:	  id,
-			Image:    path,
-			Verbose:  true,
-			Memory:   size,
-			Cpus:     config.Cpus,
-			NatRules: config.NatRules,
+			Name:	     id,
+			Image:       path,
+			Verbose:     true,
+			Memory:      size,
+			Cpus:        config.Cpus,
+			Networking:  config.Networking,
+			Bridge:      config.Bridge,
+			NatRules:    config.NatRules,
 			BackingFile: true,
 			InstanceDir: dir,
-			Monitor: filepath.Join(dir, "osv.monitor"),
-			ConfigFile: filepath.Join(dir, "osv.config"),
+			Monitor:     filepath.Join(dir, "osv.monitor"),
+			ConfigFile:  filepath.Join(dir, "osv.config"),
 		}
 		fmt.Printf("Created instance: %s\n", id);
 		tio, _ := util.RawTerm()


### PR DESCRIPTION
This patch adds bridged networking support to Capstan. You can enable it
with the "-n" command line option:

  $ capstan run -n bridge

which will use 'virbr0' device by default. You can change it with the
'-b' command line option.

Capstan will still default to port forwarding but we definitely should
switch to bridging once we support it on other hypervisors as well.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
