### PR TITLE
Capstanfile basename substitution

### DIFF
--- a/Documentation/Capstanfile.md
+++ b/Documentation/Capstanfile.md
@@ -25,3 +25,21 @@ files:
 specifies the full path of the file as it will appear in the image and the
 right side specifies a relative path to current directory of the actual file
 that is added to the image.
+
+File mapping supports basename variable substitution with the "&" character.
+You can specify this:
+
+```
+files:
+  /usr/app/app.jar: build/&
+```
+
+which expands to the following during build:
+
+```
+files:
+  /usr/app/app.jar: build/app.jar
+```
+
+Here ``/usr/app/app.jar`` is the path in the built image and ``build/app.jar``
+is the file that is picked up from the local filesystem.

--- a/util/config.go
+++ b/util/config.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
+	"path/filepath"
+	"strings"
 )
 
 type Config struct {
@@ -31,7 +33,15 @@ func ReadConfig(filename string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ParseConfig(data)
+	c, err := ParseConfig(data)
+	if err != nil {
+		return nil, err
+	}
+	err = c.substituteVars()
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 func ParseConfig(data []byte) (*Config, error) {
@@ -44,4 +54,11 @@ func ParseConfig(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("\"cmdline\" not found")
 	}
 	return &c, nil
+}
+
+func (c *Config) substituteVars() error {
+	for target, source := range c.Files {
+		c.Files[target] = strings.Replace(source, "&", filepath.Base(target), -1)
+	}
+	return nil
 }


### PR DESCRIPTION
This patch adds basename variable substitution to simplify file listing
in Capstanfile.

You can now do this to specify target and source file mapping:

  /usr/app/app.jar: build/&

which expands to:

  /usr/app/app.jar: build/app.jar

where "/usr/app/app.jar" is the path in the built image and
"build/app.jar" is the file that is picked up from the local filesystem.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
