### PR TITLE
qemu: Fix stopping an stopped instnace

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -201,9 +201,10 @@ func StopVM(name string) error {
 	}
 	conn, err := net.Dial("unix", c.Monitor)
 	if err != nil {
-		fmt.Println("Failed to stop instance: %s", name)
-		return err
+		// The instance is stopped already
+		return nil
 	}
+
 	writer := bufio.NewWriter(conn)
 
 	cmd := `{ "execute": "qmp_capabilities"}`


### PR DESCRIPTION
If we stop an stopped instance, it gives:

   $ capstan stop i1398662545
   Failed to stop instance: %s i1398662545
   Failed to stop instance: i1398662545
   Stopped instance: i1398662545

With this patch:

   $ capstan stop i1398662545
   Stopped instance: i1398662545

Signed-off-by: Asias He asias@cloudius-systems.com
