### PR TITLE
cmd/build: Upload files under ROOTFS directory

### DIFF
--- a/Documentation/Capstanfile.md
+++ b/Documentation/Capstanfile.md
@@ -43,3 +43,8 @@ files:
 
 Here ``/usr/app/app.jar`` is the path in the built image and ``build/app.jar``
 is the file that is picked up from the local filesystem.
+
+``rootfs`` specifies a directory that is amended to the base image. The directory hierarchy
+in the base image will be the same as in the rootfs directory. If rootfs is not specified
+in Capstanfile, a default rootfs directory named ROOTFS will be used. If both files and rootfs
+are specified, both will be used to amended the base image.

--- a/util/config.go
+++ b/util/config.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+	"os"
 )
 
 type Config struct {
@@ -21,6 +22,7 @@ type Config struct {
 	Cmdline string
 	Build   string
 	Files   map[string]string
+	Rootfs  string
 }
 
 func ConfigExists(filename string) bool {
@@ -52,6 +54,14 @@ func ParseConfig(data []byte) (*Config, error) {
 	}
 	if c.Cmdline == "" {
 		return nil, fmt.Errorf("\"cmdline\" not found")
+	}
+	if c.Rootfs == "" {
+		c.Rootfs = "ROOTFS"
+	} else {
+		if _, err := os.Stat(c.Rootfs); os.IsNotExist(err) {
+			fmt.Printf("Capstanfile: rootfs: %s does not exist\n", c.Rootfs)
+			return nil, err
+		}
 	}
 	return &c, nil
 }


### PR DESCRIPTION
It is boring to write a Capstanfile's file section for apps contain a
large number of files, e.g. osv/apps/cassandra/Capstanfile.

With this patch, we can put files which want to be injected into osv
image under the ROOTFS directory. capstan build will inject them all.

Signed-off-by: Asias He asias@cloudius-systems.com
