### PR TITLE
termios: Use "stty" for portability

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,8 +47,8 @@ func Run(repo *util.Repo, config *RunConfig) error {
 			fmt.Printf("Created instance: %s\n", instanceName)
 			// Do not set RawTerm for gce
 			if (instancePlatform != "gce") {
-				tio, _ := util.RawTerm()
-				defer util.ResetTerm(tio)
+				util.RawTerm()
+				defer util.ResetTerm()
 			}
 
 			var err error
@@ -144,8 +144,8 @@ func Run(repo *util.Repo, config *RunConfig) error {
 	fmt.Printf("Created instance: %s\n", id)
 	// Do not set RawTerm for gce
 	if (config.Hypervisor != "gce") {
-		tio, _ := util.RawTerm()
-		defer util.ResetTerm(tio)
+		util.RawTerm()
+		defer util.ResetTerm()
 	}
 
 	switch config.Hypervisor {

--- a/util/termios.go
+++ b/util/termios.go
@@ -10,21 +10,15 @@
 package util
 
 import (
-	"github.com/kylelemons/goat/termios"
+	"os/exec"
 )
 
-func RawTerm() (*termios.TermSettings, error) {
-	tio, err := termios.NewTermSettings(0)
-	if err != nil {
-		return nil, err
-	}
-	err = tio.Raw()
-	if err != nil {
-		return nil, err
-	}
-	return tio, err
+func RawTerm() error {
+	cmd := exec.Command("stty", "raw")
+	return cmd.Run()
 }
 
-func ResetTerm(tio *termios.TermSettings) {
-	tio.Reset()
+func ResetTerm() {
+	cmd := exec.Command("stty", "cooked")
+	cmd.Run()
 }

--- a/util/termios_windows.go
+++ b/util/termios_windows.go
@@ -7,9 +7,9 @@
 
 package util
 
-func RawTerm() (int, error) {
-	return 0, nil
+func RawTerm() error {
+	return nil
 }
 
-func ResetTerm(tio int) {
+func ResetTerm() {
 }


### PR DESCRIPTION
Use the "stty" shell command to make it possible to cross-build Darwin
version on Linux with goxc.

Signed-off-by: Pekka Enberg penberg@iki.fi
