### PR TITLE
qemu: Fix build error

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"time"
 )
 
 type VMConfig struct {
@@ -57,9 +56,7 @@ func UploadRPM(r *util.Repo, hypervisor string, image string, config *util.Confi
 	}
 	defer qemu.Process.Kill()
 
-	time.Sleep(1 * time.Second)
-
-	conn, err := net.Dial("tcp", "localhost:10000")
+	conn, err := util.ConnectAndWait("tcp", "localhost:10000")
 	if err != nil {
 		return err
 	}
@@ -95,9 +92,7 @@ func UploadFiles(r *util.Repo, hypervisor string, image string, config *util.Con
 	}
 	defer cmd.Process.Kill()
 
-	time.Sleep(1 * time.Second)
-
-	conn, err := net.Dial("tcp", "localhost:10000")
+	conn, err := util.ConnectAndWait("tcp", "localhost:10000")
 	if err != nil {
 		return err
 	}
@@ -135,9 +130,8 @@ func SetArgs(r *util.Repo, hypervisor, image string, args string) error {
 	}
 	go io.Copy(os.Stdout, stdout)
 	go io.Copy(os.Stderr, stderr)
-	time.Sleep(1 * time.Second)
 
-	conn, err := net.Dial("tcp", "localhost:10809")
+	conn, err := util.ConnectAndWait("tcp", "localhost:10809")
 	if err != nil {
 		return err
 	}

--- a/hypervisor/vbox/vbox.go
+++ b/hypervisor/vbox/vbox.go
@@ -54,7 +54,7 @@ func LaunchVM(c *VMConfig) (*exec.Cmd, error) {
 		return nil, err
 	}
 
-	conn, err := util.ConnectAndWait(c.sockPath())
+	conn, err := util.ConnectAndWait("unix", c.sockPath())
 	if err != nil {
 		return nil, err
 	}

--- a/hypervisor/vmw/vmw.go
+++ b/hypervisor/vmw/vmw.go
@@ -84,7 +84,7 @@ func LaunchVM(c *VMConfig) (*exec.Cmd, error) {
 		return nil, err
 	}
 
-	conn, err := util.ConnectAndWait(c.sockPath())
+	conn, err := util.ConnectAndWait("unix", c.sockPath())
 	if err != nil {
 		return nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -66,11 +66,11 @@ func SearchInstance(name string) (instanceName, instancePlatform string) {
 	return
 }
 
-func ConnectAndWait(path string) (net.Conn, error) {
+func ConnectAndWait(network, path string) (net.Conn, error) {
 	var conn net.Conn
 	var err error
 	for i := 0; i < 20; i++ {
-		conn, err = Connect(path)
+		conn, err = Connect(network, path)
 		if err == nil {
 			break
 		}

--- a/util/util_posix.go
+++ b/util/util_posix.go
@@ -13,6 +13,6 @@ import (
 	"net"
 )
 
-func Connect(path string) (net.Conn, error) {
-	return net.Dial("unix", path)
+func Connect(network, path string) (net.Conn, error) {
+	return net.Dial(network, path)
 }

--- a/util/util_win.go
+++ b/util/util_win.go
@@ -14,6 +14,6 @@ import (
 	"net"
 )
 
-func Connect(path string) (net.Conn, error) {
+func Connect(network, path string) (net.Conn, error) {
 	return npipe.Dial(path)
 }


### PR DESCRIPTION
People seeing this:

   $ go get github.com/cloudius-systems/capstan
   $ git clone https://github.com/syuu1228/capstan-mruby-simplehttpserver.git
   $ cd cpastan-mruby-simplehttpserver
   $ capstan run
   Building capstan-mruby-simplehttpserver...
   Fetching cloudius/osv-base/index.yaml...134 bytes downloaded.
   Fetching cloudius/osv-base/osv-base.qemu.gz...16384000 bytes downloaded.
   dial tcp 127.0.0.1:10000: connection refused

This is a time issue between we start the vm and connect to the vm.
Use util.ConnectAndWait() to wait and try more.

Signed-off-by: Asias He asias@cloudius-systems.com
