### PR TITLE
gce: Introduce --gce-upload-dir option

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -97,6 +97,7 @@ func main() {
 				cli.BoolFlag{"v", "verbose mode"},
 				cli.StringFlag{"b", "", "networking bridge: e.g., virbr0, vboxnet0"},
 				cli.StringSliceFlag{"f", new(cli.StringSlice), "port forwarding rules"},
+				cli.StringFlag{"gce-upload-dir", "",  "Directory to upload local image to: e.g., gs://osvimg"},
 			},
 			Action: func(c *cli.Context) {
 				config := &cmd.RunConfig{
@@ -109,6 +110,7 @@ func main() {
 					Networking:   c.String("n"),
 					Bridge:       c.String("b"),
 					NatRules:     nat.Parse(c.StringSlice("f")),
+					GCEUploadDir: c.String("gce-upload-dir"),
 				}
 				err := cmd.Run(repo, config)
 				if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,6 +32,7 @@ type RunConfig struct {
 	Networking   string
 	Bridge       string
 	NatRules     []nat.Rule
+	GCEUploadDir string
 }
 
 func Run(repo *util.Repo, config *RunConfig) error {
@@ -196,8 +197,7 @@ func Run(repo *util.Repo, config *RunConfig) error {
 			return fmt.Errorf("%s: image format of %s is not supported, unable to run it.", config.Hypervisor, path)
 		}
 		dir := filepath.Join(util.HomePath(), ".capstan/instances/gce", id)
-		bucket := "osvimg"
-		config := &gce.VMConfig{
+		c := &gce.VMConfig{
 			Name:             id,
 			Image:		  id,
 			Network:          "default",
@@ -207,13 +207,13 @@ func Run(repo *util.Repo, config *RunConfig) error {
 			InstanceDir:	  dir,
 		}
 		if format == image.GCE_TARBALL {
-			config.CloudStoragePath = "gs://" + bucket + "/" + id + ".tar.gz"
-			config.Tarball = path
+			c.CloudStoragePath = strings.TrimSuffix(config.GCEUploadDir, "/") + "/" + id + ".tar.gz"
+			c.Tarball = path
 		} else {
-			config.CloudStoragePath = path
-			config.Tarball = ""
+			c.CloudStoragePath = path
+			c.Tarball = ""
 		}
-		cmd, err = gce.LaunchVM(config)
+		cmd, err = gce.LaunchVM(c)
 	case "vmw":
 		if format != image.VMDK {
 			return fmt.Errorf("%s: image format of %s is not supported, unable to run it.", config.Hypervisor, path)


### PR DESCRIPTION
This specifes a Google Cloud Storage directory to upload local image to.

$ capstan run -p gce --gce-upload-dir gs://my_bucket -i ./local.osv.image.tar.gz $instance_name

will upload the local OSv image to GCE and start a OSv instance.

Signed-off-by: Asias He asias@cloudius-systems.com
