### PR TITLE
gce: Check if user logins with GCE

### DIFF
--- a/hypervisor/gce/gce.go
+++ b/hypervisor/gce/gce.go
@@ -33,7 +33,12 @@ type VMConfig struct {
 }
 
 func LaunchVM(c *VMConfig) (*exec.Cmd, error) {
-	err := vmUploadImage(c)
+	err := LoginCheck()
+	if err != nil {
+		return nil, err
+	}
+
+	err = vmUploadImage(c)
 	if err != nil {
 		return nil, err
 	}
@@ -246,4 +251,19 @@ func LoadConfig(name string) (*VMConfig, error) {
 	}
 
 	return &c, nil
+}
+
+func LoginCheck() (error) {
+	_, err := exec.LookPath("gcutil")
+	if err != nil {
+		fmt.Println("gcutil is not found. Please install Google Cloud SDK:")
+		fmt.Println("https://developers.google.com/cloud/sdk")
+		return err
+	}
+	out, err := exec.Command("gcutil", "whoami").CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
It's easy for new user to forget to login with GCE before running
capstan + GCE.  Do a check and prompt friendly.

If you do not login with GCE, it will prompt:

   You do not currently have an active account selected.
   Please run:

```
 $ gcloud auth login
```

   to obtain new credentials, or if you have already logged in with a
   different account:

```
 $ gcloud config set account <account name>
```

   to select an already authenticated account to use.

Signed-off-by: Asias He asias@cloudius-systems.com
