### PR TITLE
gce: Enable GCE from the repo system

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"io/ioutil"
 )
 
 type RunConfig struct {
@@ -96,6 +97,13 @@ func Run(repo *util.Repo, config *RunConfig) error {
 				path = repo.ImagePath(config.Hypervisor, config.ImageName)
 			} else {
 				return fmt.Errorf("%s: no such image", config.ImageName)
+			}
+			if config.Hypervisor == "gce"  && !image.IsCloudImage(config.ImageName) {
+				str, err := ioutil.ReadFile(path)
+				if err != nil {
+					return err
+				}
+				path = string(str)
 			}
 		} else {
 			path = config.ImageName


### PR DESCRIPTION
With this patch, the following cmd will create a GCE instance directly from
the remote GCE url, e.g., gs://osv/v0.09/osv-iperf.gce.tar.gz.

$ capstan run -p gce cloudius/osv-iperf

The url is obtained from a file in the remote repo.

Signed-off-by: Asias He asias@cloudius-systems.com
