### PR TITLE
QEMU: Relax version number parsing

### DIFF
--- a/hypervisor/qemu/qemu.go
+++ b/hypervisor/qemu/qemu.go
@@ -316,7 +316,7 @@ func LaunchVM(c *VMConfig, extra ...string) (*exec.Cmd, error) {
 
 	StoreConfig(c)
 
-	version, err := probeVersion()
+	version, err := ProbeVersion()
 	if err != nil {
 		return nil, err
 	}
@@ -337,19 +337,23 @@ func LaunchVM(c *VMConfig, extra ...string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-func probeVersion() (*Version, error) {
+func ProbeVersion() (*Version, error) {
 	cmd := exec.Command("qemu-system-x86_64", "-version")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
-	r, err := regexp.Compile("QEMU emulator version (\\d+)\\.(\\d+)\\.(\\d+)")
+	return ParseVersion(string(out))
+}
+
+func ParseVersion(text string) (*Version, error) {
+	r, err := regexp.Compile("QEMU.*emulator version (\\d+)\\.(\\d+)\\.(\\d+)")
 	if err != nil {
 		return nil, err
 	}
-	version := r.FindStringSubmatch(string(out))
+	version := r.FindStringSubmatch(text)
 	if len(version) != 4 {
-		return nil, fmt.Errorf("unable to parse QEMU version from '%s'", string(out))
+		return nil, fmt.Errorf("unable to parse QEMU version from '%s'", text)
 	}
 	major, err := strconv.Atoi(version[1])
 	if err != nil {

--- a/hypervisor/qemu/qemu_test.go
+++ b/hypervisor/qemu/qemu_test.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ *
+ * This work is open source software, licensed under the terms of the
+ * BSD license as described in the LICENSE file in the top-level directory.
+ */
+
+package qemu
+
+import (
+	"testing"
+)
+
+var parsingtests = []struct {
+	in  string
+	out *Version
+}{
+	{"QEMU emulator version 1.6.2, Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 1, Minor: 6, Patch: 2}},
+	{"QEMU PC emulator version 0.12.1 (qemu-kvm-0.12.1.2), Copyright (c) 2003-2008 Fabrice Bellard", &Version{Major: 0, Minor: 12, Patch: 1}},
+}
+
+func TestVersionParsing(t *testing.T) {
+	for i, tt := range parsingtests {
+		version, err := ParseVersion(tt.in)
+		if err != nil {
+			t.Errorf("%d. ParseVersion(%q) => error %q, want %q", i, tt.in, err, tt.out)
+		}
+		if version.Major != tt.out.Major || version.Minor != tt.out.Minor || version.Patch != tt.out.Patch {
+			t.Errorf("%d. ParseVersion(%q) => %q, want %q", i, tt.in, version, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
Roman Shaposhnik reports:

  Here's what I'm getting on the kvm-qemu side of things:

  # capstan run cloudius/osv
  Created instance: cloudius-osv

  exec: "qemu-system-x86_64": executable file not found in $PATH

  Which is fine, since it seems like on RHEL the relevant thing is
  called kvm-qemu.

  At least that's what virsh is using. capstan, however, doesn't seem to
  like it:

  # ln -s /usr/libexec/qemu-kvm /usr/bin/qemu-system-x86_64
  # Created instance: cloudius-osv

  unable to parse QEMU version from 'QEMU PC emulator version 0.12.1
  (qemu-kvm-0.12.1.2), Copyright (c) 2003-2008 Fabrice Bellard'

  Any advice? I must be not the first one trying to run this on
  RHEL/CentOS6.

Fix the problem by relaxing QEMU version parsing regexp.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
