### PR TITLE
build: Move image building to cmd/build.go

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -10,8 +10,14 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/cloudius-systems/capstan/cpio"
 	"github.com/cloudius-systems/capstan/hypervisor/qemu"
+	"github.com/cloudius-systems/capstan/nat"
+	"github.com/cloudius-systems/capstan/nbd"
 	"github.com/cloudius-systems/capstan/util"
+	"io"
+	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -49,21 +55,21 @@ func Build(r *util.Repo, hypervisor string, image string, verbose bool) error {
 	if err != nil {
 		return err
 	}
-	err = qemu.SetArgs(r, hypervisor, image, "/tools/cpiod.so")
+	err = SetArgs(r, hypervisor, image, "/tools/cpiod.so")
 	if err != nil {
 		return err
 	}
 	if config.RpmBase != nil {
-		err = qemu.UploadRPM(r, hypervisor, image, config, verbose)
+		err = UploadRPM(r, hypervisor, image, config, verbose)
 		if err != nil {
 			return err
 		}
 	}
-	err = qemu.UploadFiles(r, hypervisor, image, config, verbose)
+	err = UploadFiles(r, hypervisor, image, config, verbose)
 	if err != nil {
 		return err
 	}
-	err = qemu.SetArgs(r, hypervisor, image, config.Cmdline)
+	err = SetArgs(r, hypervisor, image, config.Cmdline)
 	if err != nil {
 		return err
 	}
@@ -82,5 +88,152 @@ func checkConfig(config *util.Config, r *util.Repo, hypervisor string) error {
 			return errors.New(fmt.Sprintf("%s: no such file or directory", value))
 		}
 	}
+	return nil
+}
+
+func UploadRPM(r *util.Repo, hypervisor string, image string, config *util.Config, verbose bool) error {
+	file := r.ImagePath(hypervisor, image)
+	vmconfig := &qemu.VMConfig{
+		Image:       file,
+		Verbose:     verbose,
+		Memory:      64,
+		Networking:  "nat",
+		NatRules:    []nat.Rule{nat.Rule{GuestPort: "10000", HostPort: "10000"}},
+		BackingFile: false,
+	}
+	vm, err := qemu.LaunchVM(vmconfig)
+	if err != nil {
+		return err
+	}
+	defer vm.Process.Kill()
+
+	conn, err := util.ConnectAndWait("tcp", "localhost:10000")
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command("rpm2cpio", config.RpmBase.Filename())
+	cmd.Stdout = conn
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	defer cmd.Wait()
+
+	err = vm.Wait()
+
+	conn.Close()
+
+	return err
+}
+
+func copyFile(conn net.Conn, src string, dst string) error {
+	fi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	cpio.WritePadded(conn, cpio.ToWireFormat(dst, cpio.C_ISREG, fi.Size()))
+	b, err := ioutil.ReadFile(src)
+	cpio.WritePadded(conn, b)
+	return nil
+}
+
+func UploadFiles(r *util.Repo, hypervisor string, image string, config *util.Config, verbose bool) error {
+	file := r.ImagePath(hypervisor, image)
+	vmconfig := &qemu.VMConfig{
+		Image:       file,
+		Verbose:     verbose,
+		Memory:      64,
+		Networking:  "nat",
+		NatRules:    []nat.Rule{nat.Rule{GuestPort: "10000", HostPort: "10000"}},
+		BackingFile: false,
+	}
+	cmd, err := qemu.LaunchVM(vmconfig)
+	if err != nil {
+		return err
+	}
+	defer cmd.Process.Kill()
+
+	conn, err := util.ConnectAndWait("tcp", "localhost:10000")
+	if err != nil {
+		return err
+	}
+
+	if _, err = os.Stat(config.Rootfs); !os.IsNotExist(err) {
+		err = filepath.Walk(config.Rootfs, func(src string, info os.FileInfo, _ error) error {
+			if info.IsDir() {
+				return nil
+			}
+			dst := strings.Replace(src, config.Rootfs, "", -1)
+			if verbose {
+				fmt.Println(src + "  --> " + dst)
+			}
+			return copyFile(conn, src, dst)
+		})
+	}
+
+	for dst, src := range config.Files {
+		err = copyFile(conn, src, dst)
+		if verbose {
+			fmt.Println(src + "  --> " + dst)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	cpio.WritePadded(conn, cpio.ToWireFormat("TRAILER!!!", 0, 0))
+
+	conn.Close()
+	return cmd.Wait()
+}
+
+func SetArgs(r *util.Repo, hypervisor, image string, args string) error {
+	file := r.ImagePath(hypervisor, image)
+	cmd := exec.Command("qemu-nbd", file)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+	go io.Copy(os.Stdout, stdout)
+	go io.Copy(os.Stderr, stderr)
+
+	conn, err := util.ConnectAndWait("tcp", "localhost:10809")
+	if err != nil {
+		return err
+	}
+
+	session := &nbd.NbdSession{
+		Conn:   conn,
+		Handle: 0,
+	}
+	if err := session.Handshake(); err != nil {
+		return err
+	}
+
+	padding := 512 - (len(args) % 512)
+
+	data := append([]byte(args), make([]byte, padding)...)
+
+	if err := session.Write(512, data); err != nil {
+		return err
+	}
+	if err := session.Flush(); err != nil {
+		return err
+	}
+	if err := session.Disconnect(); err != nil {
+		return err
+	}
+	conn.Close()
+	cmd.Wait()
+
 	return nil
 }


### PR DESCRIPTION
Move the image building code from QEMU driver to cmd/build.go. This is
the first step into killing the QEMU dependency for building images and
use whatever hypervisor is available on the system.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
