### PR TITLE
gce: Fix gce image path name

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -104,7 +104,7 @@ func Run(repo *util.Repo, config *RunConfig) error {
 				if err != nil {
 					return err
 				}
-				path = string(str)
+				path = strings.Replace(string(str), "\n", "", -1)
 			}
 		} else {
 			path = config.ImageName


### PR DESCRIPTION
gs path read from the repo system contains a "\n" which makes gcutil
fails to add the image.  Drop the "\n" in the path.

Signed-off-by: Asias He asias@cloudius-systems.com
