### PR TITLE
Support pre-configured tap devices in vbox

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -200,6 +200,7 @@ func Run(repo *util.Repo, config *RunConfig) error {
 			Bridge:     bridge,
 			NatRules:   config.NatRules,
 			ConfigFile: filepath.Join(dir, "osv.config"),
+			MAC:        config.MAC,
 		}
 		cmd, err = vbox.LaunchVM(config)
 	case "gce":


### PR DESCRIPTION
#122

Couple of issues:
- `vmMAC` is copied from qemu version - should be a shared function somewhere?
- should `bridge` mode use `macaddr` flag too?

I see the VM getting a dhcp address via Fold/nfdhcpd on the tap interface so it's working.
