### PR TITLE
build: Fix CPIO permissions

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -132,7 +132,12 @@ func copyFile(conn net.Conn, src string, dst string) error {
 	}
 
 	if fi.IsDir() {
-		cpio.WritePadded(conn, cpio.ToWireFormat(dst, cpio.C_ISDIR, 0))
+		fi, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+		perm := uint64(fi.Mode()) & 0777
+		cpio.WritePadded(conn, cpio.ToWireFormat(dst, cpio.C_ISDIR | perm, 0))
 		return nil
 	}
 
@@ -144,7 +149,12 @@ func copyFile(conn net.Conn, src string, dst string) error {
 		if err != nil {
 			return nil
 		}
-		cpio.WritePadded(conn, cpio.ToWireFormat(dst, cpio.C_ISREG, fi.Size()))
+		fi, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+		perm := uint64(fi.Mode()) & 0777
+		cpio.WritePadded(conn, cpio.ToWireFormat(dst, cpio.C_ISREG | perm, fi.Size()))
 		cpio.WritePadded(conn, contents)
 	}
 


### PR DESCRIPTION
As pointed out by Nadav, Capstan doesn't set permissions as part of the
file mode. Fixes #128.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
