### PR TITLE
Rename "capstan" package as "core"

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -9,8 +9,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan/capstan"
 	"github.com/cloudius-systems/capstan/cmd"
+	"github.com/cloudius-systems/capstan/core"
 	"github.com/cloudius-systems/capstan/hypervisor"
 	"github.com/cloudius-systems/capstan/nat"
 	"github.com/cloudius-systems/capstan/util"
@@ -148,11 +148,11 @@ func main() {
 					return
 				}
 				hypervisor := c.String("p")
-				image := &capstan.Image{
+				image := &core.Image{
 					Name:       imageName,
 					Hypervisor: hypervisor,
 				}
-				template, err := capstan.ReadTemplateFile("Capstanfile")
+				template, err := core.ReadTemplateFile("Capstanfile")
 				if err != nil {
 					fmt.Println(err.Error())
 					return

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,8 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cheggaaa/pb"
-	"github.com/cloudius-systems/capstan/capstan"
 	"github.com/cloudius-systems/capstan/cpio"
+	"github.com/cloudius-systems/capstan/core"
 	"github.com/cloudius-systems/capstan/hypervisor/qemu"
 	"github.com/cloudius-systems/capstan/nat"
 	"github.com/cloudius-systems/capstan/nbd"
@@ -27,7 +27,7 @@ import (
 	"strings"
 )
 
-func Build(r *util.Repo, image *capstan.Image, template *capstan.Template, verbose bool, mem string) error {
+func Build(r *util.Repo, image *core.Image, template *core.Template, verbose bool, mem string) error {
 	if err := os.MkdirAll(filepath.Dir(r.ImagePath(image.Hypervisor, image.Name)), 0777); err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func Build(r *util.Repo, image *capstan.Image, template *capstan.Template, verbo
 	return SetArgs(r, image.Hypervisor, image.Name, template.Cmdline)
 }
 
-func checkConfig(t *capstan.Template, r *util.Repo, hypervisor string) error {
+func checkConfig(t *core.Template, r *util.Repo, hypervisor string) error {
 	if _, err := os.Stat(r.ImagePath(hypervisor, t.Base)); os.IsNotExist(err) {
 		if err := Pull(r, hypervisor, t.Base); err != nil {
 			return err
@@ -80,7 +80,7 @@ func checkConfig(t *capstan.Template, r *util.Repo, hypervisor string) error {
 	return nil
 }
 
-func UploadRPM(r *util.Repo, hypervisor string, image string, template *capstan.Template, verbose bool, mem string) error {
+func UploadRPM(r *util.Repo, hypervisor string, image string, template *core.Template, verbose bool, mem string) error {
 	file := r.ImagePath(hypervisor, image)
 	size, err := util.ParseMemSize(mem)
 	if err != nil {
@@ -161,7 +161,7 @@ func copyFile(conn net.Conn, src string, dst string) error {
 	return nil
 }
 
-func UploadFiles(r *util.Repo, hypervisor string, image string, t *capstan.Template, verbose bool, mem string) error {
+func UploadFiles(r *util.Repo, hypervisor string, image string, t *core.Template, verbose bool, mem string) error {
 	file := r.ImagePath(hypervisor, image)
 	size, err := util.ParseMemSize(mem)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,7 +9,7 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/cloudius-systems/capstan/capstan"
+	"github.com/cloudius-systems/capstan/core"
 	"github.com/cloudius-systems/capstan/hypervisor/gce"
 	"github.com/cloudius-systems/capstan/hypervisor/qemu"
 	"github.com/cloudius-systems/capstan/hypervisor/vbox"
@@ -141,14 +141,14 @@ func Run(repo *util.Repo, config *RunConfig) error {
 			return fmt.Errorf("No Capstanfile found, unable to run.")
 		}
 		if !repo.ImageExists(config.Hypervisor, config.ImageName) {
-			if !capstan.IsTemplateFile("Capstanfile") {
+			if !core.IsTemplateFile("Capstanfile") {
 				return fmt.Errorf("%s: no such image", config.ImageName)
 			}
-			image := &capstan.Image{
+			image := &core.Image{
 				Name:       config.ImageName,
 				Hypervisor: config.Hypervisor,
 			}
-			template, err := capstan.ReadTemplateFile("Capstanfile")
+			template, err := core.ReadTemplateFile("Capstanfile")
 			if err != nil {
 				return err
 			}
@@ -286,12 +286,12 @@ func Run(repo *util.Repo, config *RunConfig) error {
 func buildJarImage(repo *util.Repo, config *RunConfig) (*RunConfig, error) {
 	jarPath := config.ImageName
 	imageName, jarName := parseJarNames(jarPath)
-	image := &capstan.Image{
+	image := &core.Image{
 		Name:       imageName,
 		Hypervisor: config.Hypervisor,
 	}
 	targetJarPath := "/" + jarName
-	template := &capstan.Template{
+	template := &core.Template{
 		Base:    "cloudius/osv-openjdk",
 		Cmdline: fmt.Sprintf("/java.so -jar %s", targetJarPath),
 		Files: map[string]string{

--- a/core/image.go
+++ b/core/image.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package core
 
 type Image struct {
 	Name       string

--- a/core/rpm.go
+++ b/core/rpm.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package core
 
 import (
 	"fmt"

--- a/core/template.go
+++ b/core/template.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package core
 
 import (
 	"fmt"

--- a/core/template_test.go
+++ b/core/template_test.go
@@ -5,7 +5,7 @@
  * BSD license as described in the LICENSE file in the top-level directory.
  */
 
-package capstan
+package core
 
 import (
 	"testing"

--- a/util/repository.go
+++ b/util/repository.go
@@ -10,7 +10,7 @@ package util
 import (
 	"errors"
 	"fmt"
-	"github.com/cloudius-systems/capstan/capstan"
+	"github.com/cloudius-systems/capstan/core"
 	"github.com/cloudius-systems/capstan/image"
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
@@ -143,7 +143,7 @@ func (r *Repo) ListImages() {
 }
 
 func (r *Repo) DefaultImage() string {
-	if !capstan.IsTemplateFile("Capstanfile") {
+	if !core.IsTemplateFile("Capstanfile") {
 		return ""
 	}
 	pwd, err := os.Getwd()


### PR DESCRIPTION
The "go build" command won't work if there's a "capstan" directory in
the top-level directory. Rename the package to "core" instead.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
