### PR TITLE
Fixed Outdated Description of Capstan File

### DIFF
--- a/Documentation/Capstanfile.md
+++ b/Documentation/Capstanfile.md
@@ -5,7 +5,7 @@ The ``Capstanfile`` is a YAML config file for specifying Capstan images.
 An minimal file looks as follows:
 
 ```
-base: osv-base
+base: cloudius/osv-base
 
 cmdline: /tools/hello.so
 
@@ -15,7 +15,7 @@ files:
   /tools/hello.so: hello.so
 ```
 
-``base`` specifies the base image that is amended with ``files``.
+``base`` specifies the base image that is amended with ``files`` use ``capstan search`` (remote images) or ``capstan images`` (local images) for a list of available images.
 
 ``cmdline`` is the startup command line passed to OSv.
 


### PR DESCRIPTION
Hey,
the description of Capstan File seemed a little outdated since the cloudius prefix were missing for the base image. I also referenced the capstan search / capstan images commands for listing all available images a user can choose from for completeness.