### PR TITLE
fixed capstan rmi for windows

### DIFF
--- a/util/repository.go
+++ b/util/repository.go
@@ -15,7 +15,6 @@ import (
 	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 )
@@ -108,8 +107,7 @@ func (r *Repo) RemoveImage(image string) error {
 		return errors.New(fmt.Sprintf("%s: no such image\n", image))
 	}
 	fmt.Printf("Removing %s...\n", image)
-	cmd := exec.Command("rm", "-rf", path)
-	_, err := cmd.Output()
+	err := os.RemoveAll(path)
 	return err
 }
 


### PR DESCRIPTION
Hi,

this pull request makes capstan rmi work on Windows by replacing `os.exec("rm -rf")` by `os.RemoveAll`

Cheers,
Hans