### PR TITLE
 When running on windows ´capstan build -v -p vbox´ missing imageName…

### DIFF
--- a/capstan.go
+++ b/capstan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cloudius-systems/capstan/util"
 	"github.com/codegangsta/cli"
 	"os"
+	"runtime"
 )
 
 var (
@@ -164,7 +165,7 @@ func main() {
 			Action: func(c *cli.Context) {
 				imageName := c.Args().First()
 				repo := util.NewRepo(c.String("u"))
-				if len(c.Args()) != 1 {
+				if len(c.Args()) != 1 && runtime.GOOS != "windows" {
 					imageName = repo.DefaultImage()
 				}
 				if imageName == "" {


### PR DESCRIPTION
 When running on windows ```capstan build -v -p vbox``` missing imageName generated an error when creating FilePath for the Image at **build.go line:31**, changed it to make it mandatory for windows systems