### PR TITLE
fixed build warning of go -X flags

### DIFF
--- a/install
+++ b/install
@@ -3,6 +3,14 @@
 package=github.com/cloudius-systems/capstan
 version=$(scripts/version)
 
+IFS=' ' read -a ver <<< "$(go version)"
+IFS='.' read -a ver <<< ${ver[2]}
+if [[ ver[1] -gt 4 ]]; then
+    link_operator="="
+else
+    link_operator=" "
+fi
+
 go get $package
-go build -ldflags "-X main.VERSION '$version'" $package
+go build -ldflags "-X main.VERSION$link_operator'$version'" $package
 go install $package


### PR DESCRIPTION
When I run install script on Go1.5 environment, X flags warning has occurred with this message, 
' ... use -X main.VERSION=v0.1.8-14-g84fcdfc'.
So I've fixed it by checking Go version.
Regards