### PR TITLE
Add option for freebsd in case of $HOSTTYPE return amd64

### DIFF
--- a/scripts/download
+++ b/scripts/download
@@ -13,6 +13,7 @@ esac
 
 case "$HOSTTYPE" in
   x86_64*)  ARCH="amd64" ;;
+  amd64*)   ARCH="amd64" ;;
   *)        echo "OSv only supports 64-bit x86. Exiting." && exit 1 ;;
 esac
 


### PR DESCRIPTION
This change works on my FreeBSD 10.3