### PR TITLE
Added support to pull kernel and packages from OSv Github repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
+  - 1.10
   - 1.11
   - 1.12
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.10
   - 1.11
   - 1.12
   - tip

--- a/Documentation/ApplicationManagement.md
+++ b/Documentation/ApplicationManagement.md
@@ -14,7 +14,7 @@ feel free to let us know.*
 ## Installation
 
 You must first install Capstan from [this
-repository](https://github.com/mikelangelo-project/capstan). You can install
+repository](https://github.com/cloudius/capstan). You can install
 binary version or follow the instructions for build it from source code. Ensure
 the ``capstan`` is in your ``$PATH``.
 
@@ -48,25 +48,31 @@ USAGE:
    capstan [global options] command [command options] [arguments...]
 
 COMMANDS:
-   info         show disk image information
-   import       import an image to the local repository
-   pull         pull an image from a repository
-   rmi          delete an image from a repository
-   run          launch a VM. You may pass the image name as the first argument.
-   build        build an image
-   compose      compose the image from a folder or a file
-   images, i    list images
-   search       search a remote images
-   instances, I list instances
-   stop         stop an instance
-   delete       delete an instance
-   package      package manipulation tools
-   help, h      Shows a list of commands or help for one command
+     config            Capstan configuration
+     info              show disk image information
+     import            import an image to the local repository
+     pull              pull an image from a repository
+     rmi               delete an image from a repository
+     run               launch a VM. You may pass the image name as the first argument.
+     build             build an image
+     compose           compose the image from a folder or a file
+     images, i         list images
+     search            search a remote images
+     instances, I      list instances
+     stop              stop an instance
+     delete            delete an instance
+     package           package manipulation tools
+     stack, openstack  OpenStack manipulation tools
+     runtime           package runtime manipulation tools (meta/run.yaml)
+     volume            volume manipulation tools
+     help, h           Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   -u "https://mikelangelo-capstan.s3.amazonaws.com/"   remote repository URL
-   --help, -h                                           show help
-   --version, -v                                        print the version
+   -u value                        remote repository URL (default: "https://mikelangelo-capstan.s3.amazonaws.com/")
+   --releaseTag value, --rt value  the release tag: any, latest, v0.51.0
+   --s3                            searches and downloads from S3 repository at ("https://mikelangelo-capstan.s3.amazonaws.com/")
+   --help, -h                      show help
+   --version, -v                   print the version
 ```
 
 Each of the available commands furthermore provides additional help, for example
@@ -81,8 +87,10 @@ USAGE:
    capstan compose [command options] [arguments...]
 
 OPTIONS:
-   --loader_image, -l "mike/osv-loader" the base loader image
-   --size, -s "10G"                   size of the target user partition (use M or G suffix)
+   --loader_image value, -l value  the base loader image (default: "osv-loader")
+   --size value, -s value          size of the target user partition (use M or G suffix) (default: "10G")
+   --command_line value, -c value  command line OSv will boot with
+   --verbose, -v                   verbose mode
 ```
 
 ## Package management
@@ -99,13 +107,20 @@ USAGE:
    capstan package command [command options] [arguments...]
 
 COMMANDS:
-   init        initialise package structure
-   build       builds the package into a compressed file
-   compose     composes the package and all its dependencies into OSv image
-   collect     collects contents of this package and all required packages
-   list        lists the available packages
-   import      builds the package at the given path and imports it into a chosen repository
-   help, h     Shows a list of commands or help for one command
+     init            initialise package structure
+     build           builds the package into a compressed file
+     compose         composes the package and all its dependencies into OSv image
+     compose-remote  composes the package and all its dependencies and uploads resulting files into remote OSv instance
+     collect         collects contents of this package and all required packages
+     list            lists the available packages
+     import          builds the package at the given path and imports it into a chosen repository
+     search          searches for packages in the remote repository (partial name matches are also supported)
+     pull            pulls the package from remote repository and imports it into local package storage
+     describe        describes the package from local repository
+     update          updates local packages from remote if remote version is newer
+
+OPTIONS:
+   --help, -h  show help
 ```
 
 The following subsections explain these commands in detail.
@@ -123,7 +138,15 @@ project
 The following subsections provide more information about each of these files.
 
 #### package.yaml (required)
-TODO
+This file is a simple descriptor that allows specifying basic package attributes like name, title and its author.
+It also allows to specify a list of any other packages it depends on using require tag.
+```yaml
+name: my-super-application
+title: DEMO App
+author: myname (myname@email.com)
+require:
+    - osv.cli
+```
 
 #### run.yaml (optional)
 This file specifies run options. Actual set of options depends on runtime that this package is about

--- a/Documentation/ApplicationManagement.md
+++ b/Documentation/ApplicationManagement.md
@@ -69,7 +69,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    -u value                        remote repository URL (default: "https://mikelangelo-capstan.s3.amazonaws.com/")
-   --releaseTag value, --rt value  the release tag: any, latest, v0.51.0
+   --release-tag value, --r value  the release tag: any, latest, v0.51.0
    --s3                            searches and downloads from S3 repository at ("https://mikelangelo-capstan.s3.amazonaws.com/")
    --help, -h                      show help
    --version, -v                   print the version

--- a/Documentation/Repository.md
+++ b/Documentation/Repository.md
@@ -1,6 +1,7 @@
 # Capstan Repository
-Capstan tool downloads base unikernel and precompiled packages from publically available remote repository.
-By default, following S3 repository is used:
+Capstan tool downloads base unikernel and precompiled packages from OSv Github releases repository
+ (the default) or publicly available remote repository in AWS S3.
+If S3 mode selected (--s3), following S3 repository is used:
 
 ```
 https://mikelangelo-capstan.s3.amazonaws.com
@@ -9,8 +10,15 @@ https://mikelangelo-capstan.s3.amazonaws.com
 There is nothing special about repository, it's just a bunch of directories and files that are made
 available on the internet. No authentication is supported, just a simple HTTP/HTTPS download.
 
-## Repository Structure
-Repository is structured as follows:
+## OSv Github Repository
+By default capstan pulls OSv kernel and any required packages from [OSv Github repository](https://github.com/cloudius-systems/osv/releases).
+The global parameter ```--releaseTag``` (or ```-rt```) can be used to override default behavior and make
+capstan pull artifacts published for specific release (for example ```--rt v0.51.0```) or the latest release (```--rt latest```).
+By default capstan would pull first found artifact from the list of assets published for all releases (```--rt any```).
+
+## S3 Repository Structure
+One can use global ```--s3``` parameter to make capstan pull kernel and packages from repository in AWS S3.
+The default public repository created as part of MIKELANGELO project is structured as follows:
 
 ```
 mike

--- a/Documentation/Repository.md
+++ b/Documentation/Repository.md
@@ -12,9 +12,9 @@ available on the internet. No authentication is supported, just a simple HTTP/HT
 
 ## OSv Github Repository
 By default capstan pulls OSv kernel and any required packages from [OSv Github repository](https://github.com/cloudius-systems/osv/releases).
-The global parameter ```--releaseTag``` (or ```-rt```) can be used to override default behavior and make
-capstan pull artifacts published for specific release (for example ```--rt v0.51.0```) or the latest release (```--rt latest```).
-By default capstan would pull first found artifact from the list of assets published for all releases (```--rt any```).
+The global parameter ```--release-tag``` (or ```-r```) can be used to override default behavior and make
+capstan pull artifacts published for specific release (for example ```--r v0.51.0```) or the latest release (```--r latest```).
+By default capstan would pull first found artifact from the list of assets published for all releases (```--r any```).
 
 ## S3 Repository Structure
 One can use global ```--s3``` parameter to make capstan pull kernel and packages from repository in AWS S3.

--- a/Documentation/generated/CLI.md
+++ b/Documentation/generated/CLI.md
@@ -39,11 +39,11 @@ COMMANDS:
      help, h           Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   -u value                        remote repository URL (default: "https://mikelangelo-capstan.s3.amazonaws.com/")
-   --releaseTag value, --rt value  the release tag: any, latest, v0.51.0
-   --s3                            searches and downloads from S3 repository at ("https://mikelangelo-capstan.s3.amazonaws.com/")
-   --help, -h                      show help
-   --version, -v                   print the version
+   -u value                       remote repository URL (default: "https://mikelangelo-capstan.s3.amazonaws.com/")
+   --release-tag value, -r value  the release tag: any, latest, v0.51.0
+   --s3                           searches and downloads from S3 repository at ("https://mikelangelo-capstan.s3.amazonaws.com/")
+   --help, -h                     show help
+   --version, -v                  print the version
 
 ```
 
@@ -197,7 +197,7 @@ USAGE:
 
 OPTIONS:
    -i value                   image_name
-   -p value                   hypervisor: qemu|vbox|vmw|gce (default: "vbox")
+   -p value                   hypervisor: qemu|vbox|vmw|gce (default: "qemu")
    -m value                   memory size (default: "1G")
    -c value                   number of CPUs (default: 2)
    -n value                   networking: nat|bridge|tap|vhost (default: "nat")
@@ -314,7 +314,7 @@ OPTIONS:
 ```
 
 ---
-<sup>  Documentation compiled on: 2019/07/19 04:31
+<sup>  Documentation compiled on: 2019/07/23 12:22
   <br>
-  capstan version
+  capstan version 
 </sup>

--- a/Documentation/generated/CLI.md
+++ b/Documentation/generated/CLI.md
@@ -10,6 +10,43 @@ DO NOT MODIFY IT MANUALLY, MODIFY THE SCRIPT INSTEAD.
 Here we describe Capstan CLI in detail. Please note that this very same information can be obtained
 by adding --help flag to any of the listed commands.
 
+## General:
+```
+NAME:
+   capstan - pack, ship, and run applications in light-weight VMs
+
+USAGE:
+   capstan [global options] command [command options] [arguments...]
+
+COMMANDS:
+     config            Capstan configuration
+     info              show disk image information
+     import            import an image to the local repository
+     pull              pull an image from a remote repository
+     rmi               delete an image from a repository
+     run               launch a VM. You may pass the image name as the first argument.
+     build             build an image
+     compose           compose the image from a folder or a file
+     images, i         list images
+     search            search a remote images
+     instances, I      list instances
+     stop              stop an instance
+     delete            delete an instance
+     package           package manipulation tools
+     stack, openstack  OpenStack manipulation tools
+     runtime           package runtime manipulation tools (meta/run.yaml)
+     volume            volume manipulation tools
+     help, h           Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   -u value                        remote repository URL (default: "https://mikelangelo-capstan.s3.amazonaws.com/")
+   --releaseTag value, --rt value  the release tag: any, latest, v0.51.0
+   --s3                            searches and downloads from S3 repository at ("https://mikelangelo-capstan.s3.amazonaws.com/")
+   --help, -h                      show help
+   --version, -v                   print the version
+
+```
+
 ## Working with application packages
 These commands are useful when packaging my application into Capstan package.
 
@@ -43,8 +80,8 @@ USAGE:
 
 OPTIONS:
    --pull-missing, -p  attempt to pull packages missing from a local repository
-   --boot value        specify config_set name to boot unikernel with
    --verbose, -v       verbose mode
+   --remote            set when previewing the compose-remote
    
 
 ```
@@ -63,8 +100,9 @@ OPTIONS:
    --verbose, -v           verbose mode
    --run value             the command line to be executed in the VM
    --pull-missing, -p      attempt to pull packages missing from a local repository
-   --boot value            specify default config_set name to boot unikernel with
+   --boot value            specify default config_set name to boot unikernel with (repeatable, will be run left to right)
    --env value             specify value of environment variable e.g. PORT=8000 (repeatable)
+   --fs value              specify type of filesystem: zfs or rofs
    
 
 ```
@@ -159,7 +197,7 @@ USAGE:
 
 OPTIONS:
    -i value                   image_name
-   -p value                   hypervisor: qemu|vbox|vmw|gce (default: "qemu")
+   -p value                   hypervisor: qemu|vbox|vmw|gce (default: "vbox")
    -m value                   memory size (default: "1G")
    -c value                   number of CPUs (default: 2)
    -n value                   networking: nat|bridge|tap|vhost (default: "nat")
@@ -169,7 +207,7 @@ OPTIONS:
    --gce-upload-dir value     Directory to upload local image to: e.g., gs://osvimg
    --mac value                MAC address. If not specified, the MAC address will be generated automatically.
    --execute value, -e value  set the command line to execute
-   --boot value               specify config_set name to boot unikernel with
+   --boot value               specify config_set name to boot unikernel with (repeatable, will be run left to right)
    --persist                  persist instance parameters (only relevant for qemu instances)
    --env value                specify value of environment variable e.g. PORT=8000 (repeatable)
    --volume value             {path}[:{key=val}], e.g. ./volume.img:format=raw (repeatable)
@@ -200,7 +238,7 @@ OPTIONS:
    --keep-image              don't delete local composed image in .capstan/repository/stack
    --verbose, -v             verbose mode
    --pull-missing, -p        attempt to pull packages missing from a local repository
-   --boot value              specify config_set name to boot unikernel with
+   --boot value              specify config_set name to boot unikernel with (repeatable, will be run left to right)
    --env value               specify value of environment variable e.g. PORT=8000 (repeatable)
    --OS_AUTH_URL value       OpenStack auth url (e.g. http://10.0.2.15:5000/v2.0)
    --OS_TENANT_ID value      OpenStack tenant id (e.g. 3dfe7bf545ff4885a3912a92a4a5f8e0)
@@ -276,7 +314,7 @@ OPTIONS:
 ```
 
 ---
-<sup>  Documentation compiled on: 2017/12/18 07:08
+<sup>  Documentation compiled on: 2019/07/19 04:31
   <br>
-  capstan version 'v0.2.1-66-g4248dd0'
+  capstan version
 </sup>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Capstan is designed to prepare and run OSv unikernel for you.
 With Capstan it is possible to:
 
 * prepare OSv unikernel without compiling anything but your application, in seconds
-* use any precompiled package from the MIKELANGELO package repository, or a combination thereof
+* build OSv image using Capstanfile (ala Dockerfile) or compose it from pre-built packages
+* use any precompiled package from the OSv github releases repository or MIKELANGELO package repository, or a combination thereof
+* build your own packages or base image
 * set arbitrary size of the target unikernel filesystem
 * run OSv unikernel using one of the supported providers
 
@@ -68,7 +70,9 @@ Congratulations, your unikernel is up-and-running! Press CTRL + C to stop it.
 ## Documentation
 
 * [Step-by-step Capstan Installation Guide](Documentation/Installation.md)
+* [User Guide](Documentation/ApplicationManagement.md)
 * [Running My First Application Inside Unikernel](Documentation/WalkthroughNodeJS.md)
+* [Capstanfile](Documentation/Capstanfile.md)
 * [Configuration Files](Documentation/ConfigurationFiles.md)
     * [Native](Documentation/RuntimeNative.md)
     * [Java](Documentation/RuntimeJava.md)

--- a/capstan.go
+++ b/capstan.go
@@ -45,7 +45,7 @@ func main() {
 	app.Usage = "pack, ship, and run applications in light-weight VMs"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "u", Usage: fmt.Sprintf("remote repository URL (default: \"%s\")", util.DefaultRepositoryUrl)},
-		cli.StringFlag{Name: "releaseTag,rt", Usage: "the release tag: any, latest, v0.51.0"},
+		cli.StringFlag{Name: "release-tag,r", Usage: "the release tag: any, latest, v0.51.0"},
 		cli.BoolFlag{Name: "s3", Usage: fmt.Sprintf("searches and downloads from S3 repository at (\"%s\")", util.DefaultRepositoryUrl)},
 	}
 	app.Commands = []cli.Command{

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-func Compose(r *util.Repo, loaderImage string, imageSize int64, uploadPath string, appName string) error {
+func Compose(r *util.Repo, loaderImage string, imageSize int64, uploadPath string, appName string, commandLine string, verbose bool) error {
 	// Initialize an empty image based on the provided loader image. imageSize is used to
 	// determine the size of the user partition.
 	err := r.InitializeZfsImage(loaderImage, appName, imageSize)
@@ -42,8 +42,16 @@ func Compose(r *util.Repo, loaderImage string, imageSize int64, uploadPath strin
 	}
 
 	// Upload the specified path onto virtual image.
-	if _, err = UploadPackageContents(r, imagePath, paths, nil, false); err != nil {
+	if _, err = UploadPackageContents(r, imagePath, paths, nil, verbose); err != nil {
 		return err
+	}
+
+	if commandLine != "" {
+		// Set the command line.
+		if err = util.SetCmdLine(imagePath, commandLine); err != nil {
+			return err
+		}
+		fmt.Printf("Command line set to: '%s'\n", commandLine)
 	}
 
 	return nil

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -539,7 +539,7 @@ func extractPackageContent(tarReader *tar.Reader, target, pkgName string) (*runt
 // it into local repository.
 func PullPackage(r *util.Repo, packageName string) error {
 	// Try to download the package from the remote repository.
-	return r.DownloadPackage(r.URL, packageName)
+	return r.DownloadPackageRemote(packageName)
 }
 
 // ensureDirectoryStructureForFile creates directory path for given filepath.
@@ -736,7 +736,7 @@ func UpdatePackages(repo *util.Repo, search string, compareCreated, verbose bool
 		if verbose {
 			fmt.Printf("[%02d/%02d] %-50s", idx+1, len(localPackages), localPkg.Name)
 		}
-		remotePkg := util.RemotePackageInfo(repo.URL, fmt.Sprintf("packages/%s.yaml", localPkg.Name))
+		remotePkg := repo.PackageInfoRemote(localPkg.Name)
 		if remotePkg == nil {
 			if verbose {
 				fmt.Println("... package does not exist in remote repository")
@@ -751,7 +751,8 @@ func UpdatePackages(repo *util.Repo, search string, compareCreated, verbose bool
 			if verbose {
 				fmt.Printf("... updating %s -> %s\n", localPkg.Version, remotePkg.Version)
 			}
-			if err := repo.DownloadPackage(repo.URL, localPkg.Name); err != nil {
+
+			if err := repo.DownloadPackageRemote(localPkg.Name); err != nil {
 				return fmt.Errorf("ERROR: %s", err)
 			} else {
 				updateCount += 1

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -18,7 +18,7 @@ func Pull(r *util.Repo, hypervisor string, image string) error {
 		return err
 	}
 	if remote {
-		return r.DownloadImage(r.URL, hypervisor, image)
+		return r.DownloadImage(hypervisor, image)
 	}
 	return r.PullImage(image)
 }

--- a/scripts/generate_cli_doc.py
+++ b/scripts/generate_cli_doc.py
@@ -74,7 +74,6 @@ GROUPS = [
           ]),
 ]
 
-
 def get_command_description(command, flags=['--help']):
     stdout, stderr = subprocess.Popen(
         command.cmd.split() + flags,
@@ -102,6 +101,13 @@ DO NOT MODIFY IT MANUALLY, MODIFY THE SCRIPT INSTEAD.
 Here we describe Capstan CLI in detail. Please note that this very same information can be obtained
 by adding --help flag to any of the listed commands.
 '''
+    general_descr = get_command_description(Command('capstan'))
+    res += '''
+## General:
+```
+%s
+```
+''' % (general_descr)
 
     for group in GROUPS:
         res += '''

--- a/util/github_releases_repository.go
+++ b/util/github_releases_repository.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -210,7 +211,10 @@ func (r *Repo) githubPackageInfoRemote(packageName string) *core.Package {
 }
 
 func githubMakeReleaseApiCall(suffix string) ([]byte, error) {
-	resp, err := http.Get(OsvReleasesGitHubRepositoryApiUrl + suffix)
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := netClient.Get(OsvReleasesGitHubRepositoryApiUrl + suffix)
 	if err != nil {
 		return nil, err
 	}
@@ -218,6 +222,10 @@ func githubMakeReleaseApiCall(suffix string) ([]byte, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("The request %s returned non-200 [%d] response: %s.",
+			OsvReleasesGitHubRepositoryApiUrl+suffix, resp.StatusCode, string(body))
 	}
 	return body, nil
 }

--- a/util/github_releases_repository.go
+++ b/util/github_releases_repository.go
@@ -1,0 +1,223 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cloudius-systems/capstan/core"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	OsvReleasesGitHubRepositoryApiUrl = "https://api.github.com/repos/cloudius-systems/osv/releases"
+)
+
+type Asset struct {
+	Name        string `json:"name"`
+	Size        int    `json:"size"`
+	DownloadUrl string `json:"browser_download_url"`
+}
+
+type Release struct {
+	Id     int     `json:"id"`
+	Name   string  `json:"name"`
+	Tag    string  `json:"tag_name"`
+	Assets []Asset `json:"assets"`
+}
+
+//GET /repos/:owner/:repo/releases/latest - get latest release with assets
+// https://api.github.com/repos/cloudius-systems/osv/releases/latest
+
+//GET /repos/:owner/:repo/releases/tags/:tag - get release by tag with assets
+// https://api.github.com/repos/cloudius-systems/osv/releases/tags/v0.51.0
+
+//GET /repos/:owner/:repo/releases - get all releases with assets
+// https://api.github.com/repos/cloudius-systems/osv/releases
+
+func (r *Repo) queryReleases() ([]Release, error) {
+	apiSuffix := "/latest"
+	if r.ReleaseTag == "any" {
+		apiSuffix = ""
+	} else if r.ReleaseTag != "latest" {
+		apiSuffix = fmt.Sprintf("/tags/%s", r.ReleaseTag)
+	}
+	//
+	// Fetch release info with assets for the latest one or identified by tag
+	// or all releases each with array of assets
+	responseBytes, err := githubMakeReleaseApiCall(apiSuffix)
+	if err != nil {
+		return nil, err
+	}
+
+	var releases []Release
+	if r.ReleaseTag == "any" {
+		if err := json.Unmarshal(responseBytes, &releases); err != nil {
+			return nil, err
+		}
+	} else {
+		var release Release
+		if err := json.Unmarshal(responseBytes, &release); err != nil {
+			return nil, err
+		}
+		releases = append(releases, release)
+	}
+	return releases, nil
+}
+
+func (r *Repo) githubListPackagesRemote(search string) error {
+	releases, err := r.queryReleases()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%-10s%s\n", "Release", FileInfoHeader())
+	for _, release := range releases {
+		for _, asset := range release.Assets {
+			if strings.HasPrefix(asset.Name, "osv") && strings.HasSuffix(asset.Name, ".yaml") {
+				if pkg := remotePackageInfo(asset.DownloadUrl); pkg != nil && strings.Contains(pkg.Name, search) {
+					fmt.Printf("%-10s%s\n", release.Tag, pkg.String())
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Repo) downloadLoaderImageFromGithub(hypervisor string) (string, error) {
+	releases, err := r.queryReleases()
+	if err != nil {
+		return NewLoaderImageName, err
+	}
+
+	err = os.MkdirAll(filepath.Join(r.RepoPath(), NewLoaderImageName), os.ModePerm)
+	if err != nil {
+		return NewLoaderImageName, err
+	}
+
+	// Walk release by release until you find one that has both manifest and file asset
+	for _, release := range releases {
+		loaderFileUrl, loaderManifestUrl := "", ""
+
+		for _, asset := range release.Assets {
+			if strings.HasPrefix(asset.Name, NewLoaderImageName) && strings.HasSuffix(asset.Name, hypervisor) {
+				loaderFileUrl = asset.DownloadUrl
+			}
+
+			if asset.Name == "index.yaml" {
+				loaderManifestUrl = asset.DownloadUrl
+			}
+
+			// Both must be found for OSv loader to exist in remote repository.
+			if loaderFileUrl != "" && loaderManifestUrl != "" {
+				// Download the loader file itself
+				fileName := fmt.Sprintf("%s/%s.%s", NewLoaderImageName, NewLoaderImageName, hypervisor)
+				if err = r.downloadFile(loaderFileUrl, r.RepoPath(), fileName); err != nil {
+					return NewLoaderImageName, err
+				}
+				// .. and then a manifest
+				fileName = fmt.Sprintf("%s/index.yaml", NewLoaderImageName)
+				if err = r.downloadFile(loaderManifestUrl, r.RepoPath(), fileName); err != nil {
+					return NewLoaderImageName, err
+				}
+
+				fmt.Printf("Downloaded loader image (%s) from github.\n", NewLoaderImageName)
+				return NewLoaderImageName, nil
+			}
+		}
+	}
+
+	return NewLoaderImageName, fmt.Errorf(
+		"The loader image: %s is not available in the given release (%s) in GitHub", NewLoaderImageName, r.ReleaseTag)
+}
+
+// DownloadPackage downloads a package from the S3 repository into local.
+func (r *Repo) downloadPackageFromGithub(packageName string) error {
+	remote, err := r.getRemotePackageInfoInGithub(packageName)
+	if err != nil {
+		return err
+	}
+	// If the package is not found on a remote repository, inform the user.
+	if remote == nil {
+		return fmt.Errorf("package %s is not available in the given release (%s) in GitHub", packageName, r.ReleaseTag)
+	}
+
+	// Get the root of the packages dir.
+	packagesRoot := r.PackagesPath()
+
+	// Make sure the path exists by creating the entire directory structure.
+	err = os.MkdirAll(packagesRoot, 0775)
+	if err != nil {
+		return fmt.Errorf("%s: mkdir failed", packagesRoot)
+	}
+
+	packageManifest := fmt.Sprintf("%s.yaml", packageName)
+	packageFile := fmt.Sprintf("%s.mpm", packageName)
+
+	// Download manifest file.
+	err = r.downloadFile(remote.manifestURL, packagesRoot, packageManifest)
+	if err != nil {
+		return err
+	}
+
+	// Download package file.
+	err = r.downloadFile(remote.fileURL, packagesRoot, packageFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// getRemotePackageInfoInGithub checks that the given package is available in the remote
+// repository. In order to confirm the package really exists, both manifest
+// and the actual package content must exist in remote repository.
+func (r *Repo) getRemotePackageInfoInGithub(name string) (*RemotePackageDownloadInfo, error) {
+	// Get file listing for the remote repository.
+	releases, err := r.queryReleases()
+	if err != nil {
+		return nil, err
+	}
+
+	// Walk release by release until you find one that has both manifest and file asset
+	for _, release := range releases {
+		info := RemotePackageDownloadInfo{}
+		for _, asset := range release.Assets {
+			if asset.Name == (name + ".yaml") {
+				info.manifestURL = asset.DownloadUrl
+			}
+			if asset.Name == (name + ".mpm") {
+				info.fileURL = asset.DownloadUrl
+			}
+
+			// Both must be found for package to exist in remote repository.
+			if info.manifestURL != "" && info.fileURL != "" {
+				return &info, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (r *Repo) githubPackageInfoRemote(packageName string) *core.Package {
+	packageDownloadInfo, err := r.getRemotePackageInfoInGithub(packageName)
+	if err != nil {
+		return nil
+	}
+
+	return remotePackageInfo(packageDownloadInfo.manifestURL)
+}
+
+func githubMakeReleaseApiCall(suffix string) ([]byte, error) {
+	resp, err := http.Get(OsvReleasesGitHubRepositoryApiUrl + suffix)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}

--- a/util/github_releases_repository_test.go
+++ b/util/github_releases_repository_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"github.com/mikelangelo-project/capstan/util"
+	"github.com/cloudius-systems/capstan/util"
 	. "gopkg.in/check.v1"
 )
 

--- a/util/github_releases_repository_test.go
+++ b/util/github_releases_repository_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"github.com/cloudius-systems/capstan/util"
 	. "gopkg.in/check.v1"
 )
 
@@ -10,7 +9,7 @@ type suite struct {
 }
 
 func (s *suite) SetUpTest(c *C) {
-	s.repo = NewRepo(util.DefaultRepositoryUrl)
+	s.repo = NewRepo(DefaultRepositoryUrl)
 	s.repo.Path = c.MkDir()
 	s.repo.UseS3 = false
 }

--- a/util/github_releases_repository_test.go
+++ b/util/github_releases_repository_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"github.com/mikelangelo-project/capstan/util"
+	. "gopkg.in/check.v1"
+)
+
+type suite struct {
+	repo *Repo
+}
+
+func (s *suite) SetUpTest(c *C) {
+	s.repo = NewRepo(util.DefaultRepositoryUrl)
+	s.repo.Path = c.MkDir()
+	s.repo.UseS3 = false
+}
+
+var _ = Suite(&suite{})
+
+func (s *suite) TestGithubPackageInfoRemote(c *C) {
+	s.repo.ReleaseTag = "v0.53.0"
+	packageName := "osv.httpserver-api"
+	appPackage := s.repo.PackageInfoRemote(packageName)
+	c.Assert(appPackage, NotNil)
+	c.Check(appPackage.Name, Equals, packageName)
+}
+
+func (s *suite) TestGithubDownloadLoaderImage(c *C) {
+	s.repo.ReleaseTag = "v0.51.0"
+	loaderName, err := s.repo.DownloadLoaderImage("qemu")
+	c.Assert(err, IsNil)
+	c.Check(loaderName, Equals, "osv-loader")
+}
+
+func (s *suite) TestGithubListPackagesRemote(c *C) {
+	s.repo.ReleaseTag = "any"
+	err := s.repo.ListPackagesRemote("")
+	c.Assert(err, IsNil)
+}
+
+func (s *suite) TestGithubDownloadPackageRemote(c *C) {
+	s.repo.ReleaseTag = "v0.53.0"
+	err := s.repo.DownloadPackageRemote("osv.httpserver-api")
+	c.Assert(err, IsNil)
+}

--- a/util/remote_repository.go
+++ b/util/remote_repository.go
@@ -1,0 +1,170 @@
+package util
+
+import (
+	"compress/gzip"
+	"fmt"
+	"github.com/cheggaaa/pb"
+	"github.com/cloudius-systems/capstan/core"
+	"gopkg.in/yaml.v2"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type FileInfo struct {
+	Namespace   string
+	Name        string
+	Description string
+	Version     string
+	Created     core.YamlTime `yaml:"created"`
+	Platform    string
+}
+
+type FilesInfo struct {
+	images []FileInfo
+}
+
+type RemotePackageDownloadInfo struct {
+	manifestURL string
+	fileURL     string
+}
+
+func FileInfoHeader() string {
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s %-15s", "Name", "Description", "Version", "Created", "Platform")
+	return strings.TrimSpace(res)
+}
+
+func (f *FileInfo) String() string {
+	// Trim "/" prefix if there is one (happens when namespace is empty)
+	name := strings.TrimLeft(f.Namespace+"/"+f.Name, "/")
+	platform := f.Platform
+	if platform == "" {
+		platform = "N/A"
+	}
+	res := fmt.Sprintf("%-50s %-50s %-15s %-20s %-15s", name, f.Description, f.Version, f.Created, platform)
+	return strings.TrimSpace(res)
+}
+
+func ParseIndexYaml(path, ns, name string) (*FileInfo, error) {
+	data, err := ioutil.ReadFile(filepath.Join(path, ns, name, "index.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	f := FileInfo{}
+	err = yaml.Unmarshal(data, &f)
+	if err != nil {
+		return nil, err
+	}
+	f.Namespace = ns
+	f.Name = name
+	return &f, nil
+}
+
+func RemoteFileInfo(repo_url string, path string) *FileInfo {
+	resp, err := http.Get(repo_url + path)
+	if err != nil {
+		return nil
+	}
+
+	parts := strings.Split(path, "/")
+	defer resp.Body.Close()
+	f := FileInfo{}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+	err = yaml.Unmarshal(data, &f)
+	if err != nil {
+		return nil
+	}
+	if err != nil {
+		return nil
+	}
+	f.Namespace = parts[0]
+	f.Name = parts[1]
+	return &f
+}
+
+// remotePackageInfo downloads the given manifest files and tries to parse it.
+// core.Package struct is returned if it succeeds, otherwise nil.
+func remotePackageInfo(package_url string) *core.Package {
+	resp, err := http.Get(package_url)
+	if err != nil {
+		return nil
+	}
+
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	var pkg core.Package
+
+	if err := pkg.Parse(data); err != nil {
+		return nil
+	}
+
+	return &pkg
+}
+
+func NeedsUpdate(localPkg, remotePkg *core.Package, compareCreated bool) (bool, error) {
+	// Compare Version attribute.
+	localVersion, err := VersionStringToInt(localPkg.Version)
+	if err != nil {
+		return true, err
+	}
+	remoteVersion, err := VersionStringToInt(remotePkg.Version)
+	if err != nil {
+		return true, err
+	}
+	needsUpdate := localVersion < remoteVersion
+	if needsUpdate || !compareCreated {
+		return needsUpdate, nil
+	}
+
+	// Compare Created attribute.
+	createdLocal := localPkg.Created.GetTime()
+	createdRemote := remotePkg.Created.GetTime()
+	if createdLocal == nil || createdRemote == nil {
+		return true, nil
+	}
+	return createdLocal.Before(*createdRemote), nil
+}
+
+func (r *Repo) downloadFile(fileURL string, destPath string, name string) error {
+	compressed := strings.HasSuffix(fileURL, ".gz")
+	output, err := os.Create(filepath.Join(destPath, strings.TrimSuffix(name, ".gz")))
+	if err != nil {
+		return err
+	}
+	defer output.Close()
+	fmt.Printf("Downloading %s... from %s\n", name, fileURL)
+	tr := &http.Transport{
+		DisableCompression: true,
+		Proxy:              http.ProxyFromEnvironment,
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(fileURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	bar := pb.New64(resp.ContentLength).SetUnits(pb.U_BYTES)
+	bar.Start()
+	proxyReader := bar.NewProxyReader(resp.Body)
+	var reader io.Reader = proxyReader
+	if compressed {
+		gzipReader, err := gzip.NewReader(proxyReader)
+		if err != nil {
+			return err
+		}
+		reader = gzipReader
+	}
+	_, err = io.Copy(output, reader)
+	bar.Finish()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/util/repository.go
+++ b/util/repository.go
@@ -105,8 +105,8 @@ func NewRepoFromCli(c *cli.Context) *Repo {
 	repo := NewRepo(c.GlobalString("u"))
 	repo.UseS3 = c.GlobalBool("s3")
 
-	if c.GlobalString("releaseTag") != "" {
-		repo.ReleaseTag = c.GlobalString("releaseTag")
+	if c.GlobalString("release-tag") != "" {
+		repo.ReleaseTag = c.GlobalString("release-tag")
 	}
 
 	return repo

--- a/util/s3_repository.go
+++ b/util/s3_repository.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -34,7 +35,10 @@ type Query struct {
 }
 
 func queryRemote(repo_url string) (*Query, error) {
-	resp, err := http.Get(repo_url)
+	var netClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, err := netClient.Get(repo_url)
 	if err != nil {
 		return nil, err
 	}
@@ -42,6 +46,10 @@ func queryRemote(repo_url string) (*Query, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("The request %s returned non-200 [%d] response: %s.",
+			repo_url, resp.StatusCode, string(body))
 	}
 	var q Query
 	xml.Unmarshal(body, &q)


### PR DESCRIPTION
This pull request enhances capstan to be able to pull OSv kernel (loader) and packages from OSv github repository as a more up-to-date alternative to the old MIKELANNGELO S3 repository. 

It adds two new global parameters ```--releaseTag``` and ```--s3``` which allow specifying which OSv release pull artifacts from or whether to pull it from S3.

In addition, it updates some relevant documentation to make it better reflect new features.

Signed-off-by: Waldemar Kozaczuk <jwkozaczuk@gmail.com>