### PR TITLE
Update qemu command line arguments

### DIFF
--- a/hypervisor/qemu/qemu_test.go
+++ b/hypervisor/qemu/qemu_test.go
@@ -62,7 +62,7 @@ func (s *suite) TestVmArguments(c *C) {
 				"-device", "isa-serial,chardev=stdio",
 				"-netdev", "user,id=un0,net=192.168.122.0/24,host=192.168.122.1",
 				"-device", "virtio-net-pci,netdev=un0",
-				"-chardev", "socket,id=charmonitor,path=,server,nowait",
+				"-chardev", "socket,id=charmonitor,path=,server=on,wait=off",
 				"-mon", "chardev=charmonitor,id=monitor,mode=control",
 			},
 		},


### PR DESCRIPTION
- Updated deprecated command line flags: `server=on` and `wait=off`
- Added missing command line flag: `-F qcow2`
- Logging the error if `qemu-img` fails